### PR TITLE
ApplicationController#current_ability optimization

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,9 +34,10 @@ class ApplicationController < ActionController::Base
   rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
 
   def current_ability
+    return @current_ability if @current_ability
     session = Session.find(params[:session_id]) if params[:session_id].present?
     reviewer = Reviewer.find(params[:reviewer_id]) if params[:reviewer_id].present?
-    @current_ability ||= Ability.new(current_user, @conference, session, reviewer)
+    @current_ability = Ability.new(current_user, @conference, session, reviewer)
   end
 
   def default_url_options(_options = {})

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -22,4 +22,37 @@ describe 'ApplicationController' do
       end
     end
   end
+
+  describe '#current_ability' do
+    let(:controller) { ApplicationController.new }
+
+    let(:session_id) { 'the-session-id' }
+    let(:session) { Session.new }
+    let(:reviewer_id) { 'the-reviewer-id' }
+    let(:reviewer) { Reviewer.new }
+
+    before do
+      controller.stubs(:params).returns(session_id: session_id, reviewer_id: reviewer_id)
+      controller.stubs(:current_user).returns(User.new)
+    end
+
+    context 'when current ability is not set' do
+      it 'load session and reviewer from database' do
+        Session.expects(:find).times(1).with(session_id).returns(session)
+        Reviewer.expects(:find).times(1).with(reviewer_id).returns(reviewer)
+        current_ability = controller.current_ability
+        expect(current_ability.session).to equal(session)
+        expect(current_ability.reviewer).to equal(reviewer)
+      end
+    end
+
+    context 'when current ability is set' do
+      it 'load session and reviewer from database' do
+        Session.expects(:find).times(1).with(session_id).returns(session)
+        Reviewer.expects(:find).times(1).with(reviewer_id).returns(reviewer)
+        controller.current_ability
+        controller.current_ability
+      end
+    end
+  end
 end


### PR DESCRIPTION
On this change, ApplicationController#current_ability method will only query database when local `@current_ability` is not set.